### PR TITLE
Upgrades-by-default for new VMs + startup spinner + UX polish

### DIFF
--- a/docs/superpowers/plans/2026-04-21-upgrades-by-default.md
+++ b/docs/superpowers/plans/2026-04-21-upgrades-by-default.md
@@ -1,0 +1,391 @@
+# Upgrades-by-default Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make new VMs upgradeable by default (opt-out via `--disable-upgrades`), show a spinner during the create-VM HTTP call in interactive mode, and fix the post-create success message to reference the correct command name.
+
+**Architecture:** Three focused edits in the `vm create` command. The spinner lives in its own new file (`src/spinner.ts`) as a tiny inline utility — no new dependency. The CLI-option and default-behavior changes live in `src/cli.ts`, `src/types.d.ts`, and `src/commands/vm/create.ts`.
+
+**Tech Stack:** TypeScript, Commander.js (CLI), Inquirer (interactive prompts), Node.js `process.stdout` for spinner rendering.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `src/spinner.ts` — spinner utility (`startSpinner(text) → stop`).
+- **Modify:** `src/cli.ts` — add `--disable-upgrades` option on the `vm create` subcommand.
+- **Modify:** `src/types.d.ts` — add `disableUpgrades?: boolean` to `CreateVmCommandOptions`.
+- **Modify:** `src/commands/vm/create.ts`:
+  - Replace the upgradeability default-on logic.
+  - Wrap the `apiClient.post` with the spinner in interactive mode.
+  - Fix the `list-vms` → `vm list` message.
+
+No test files — this project has no test harness. Verification is manual (build + runtime smoke test).
+
+---
+
+## Task 1: Add the `--disable-upgrades` CLI option
+
+**Files:**
+- Modify: `src/cli.ts:94` (adjacent to the existing `--upgradeability` option)
+- Modify: `src/types.d.ts:134-154` (`CreateVmCommandOptions` interface)
+
+- [ ] **Step 1: Add `disableUpgrades` to the type**
+
+Edit `src/types.d.ts`. Find the `CreateVmCommandOptions` interface (line 134) and add the new optional field right after `upgradeability`:
+
+```ts
+export interface CreateVmCommandOptions {
+    name?: string;
+    type?: string;
+    dockerCompose?: string;
+    template?: string;
+    inviteCode?: string;
+    tls?: boolean;
+    env?: string;
+    domain?: string;
+    dockerCredentials?: string;
+    dockerRegistry?: string;
+    persistence?: boolean;
+    upgradeability?: boolean;
+    disableUpgrades?: boolean;
+    private?: boolean;
+    platform?: string;
+    environment?: string;
+    archive?: string;
+    kms?: string;
+    eip8004RegistrationJson?: string;
+    eip8004Chain?: string;
+}
+```
+
+- [ ] **Step 2: Add the CLI option**
+
+Edit `src/cli.ts`. Find line 94:
+
+```ts
+.option("-u, --upgradeability", "Enable SecretVM upgradeability")
+```
+
+Insert the new `--disable-upgrades` option immediately after it. Leave the existing `--upgradeability` line exactly as-is (the spec treats it as silently accepted — no help-text change):
+
+```ts
+.option("-u, --upgradeability", "Enable SecretVM upgradeability")
+.option(
+    "--disable-upgrades",
+    "Disable SecretVM upgradeability for this VM",
+)
+```
+
+- [ ] **Step 3: Build to verify types compile**
+
+Run: `npm run build`
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli.ts src/types.d.ts
+git commit -m "Add --disable-upgrades CLI option and type"
+```
+
+---
+
+## Task 2: Flip upgradeability default and handle opt-out in `create.ts`
+
+**Files:**
+- Modify: `src/commands/vm/create.ts:36` (variable init)
+- Modify: `src/commands/vm/create.ts:404-415` (interactive prompt)
+- Modify: `src/commands/vm/create.ts:683-685` (form submission — unchanged logic, but verify)
+
+- [ ] **Step 1: Replace the initial `upgradeability` assignment**
+
+Edit `src/commands/vm/create.ts`. Find line 36:
+
+```ts
+    let upgradeability = cmdOptions.upgradeability;
+```
+
+Replace with:
+
+```ts
+    let upgradeability = !cmdOptions.disableUpgrades;
+```
+
+This establishes the new default: if the user did not pass `--disable-upgrades`, start with `upgradeability = true`.
+
+- [ ] **Step 2: Update the interactive prompt**
+
+Edit `src/commands/vm/create.ts`. Find the block at lines 404-415:
+
+```ts
+                if (!upgradeability) {
+                    const { enableUpgradeability } = await inquirer.prompt([
+                        {
+                            type: "confirm",
+                            name: "enableUpgradeability",
+                            message:
+                                "Do you want to enable SecretVM upgradeability?",
+                            default: false,
+                        },
+                    ]);
+                    upgradeability = enableUpgradeability;
+                }
+```
+
+Replace with:
+
+```ts
+                if (!cmdOptions.disableUpgrades) {
+                    const { enableUpgradeability } = await inquirer.prompt([
+                        {
+                            type: "confirm",
+                            name: "enableUpgradeability",
+                            message:
+                                "Do you want to enable SecretVM upgradeability?",
+                            default: true,
+                        },
+                    ]);
+                    upgradeability = enableUpgradeability;
+                }
+```
+
+Changes: prompt is now gated on `cmdOptions.disableUpgrades` (so the prompt is skipped when the user explicitly opted out on the CLI), and its default is flipped to `true`.
+
+- [ ] **Step 3: Verify the form submission is unchanged**
+
+The block at lines 683-685 should already read:
+
+```ts
+            if (upgradeability) {
+                formData.append("upgradeability", "1");
+            }
+```
+
+No change required. This block now fires by default (because `upgradeability` is `true` by default) and not when `--disable-upgrades` is set.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Smoke test — interactive default**
+
+Run: `node dist/cli.js vm create` (or `npm run dev -- vm create` via ts-node)
+
+Walk the wizard. When you reach the upgradeability prompt, confirm:
+- Prompt text: "Do you want to enable SecretVM upgradeability?"
+- Default shown as `(Y/n)` (i.e., yes).
+
+You can Ctrl-C out before actually creating the VM.
+
+- [ ] **Step 6: Smoke test — interactive with `--disable-upgrades` skips prompt**
+
+Run: `node dist/cli.js vm create --disable-upgrades`
+
+Walk the wizard. The upgradeability prompt should NOT appear at all.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/vm/create.ts
+git commit -m "Default new VMs to upgradeable; respect --disable-upgrades"
+```
+
+---
+
+## Task 3: Create the spinner utility
+
+**Files:**
+- Create: `src/spinner.ts`
+
+- [ ] **Step 1: Write the spinner module**
+
+Create `src/spinner.ts` with this exact content:
+
+```ts
+const FRAMES = ["|", "/", "-", "\\"];
+const INTERVAL_MS = 100;
+
+export function startSpinner(text: string): () => void {
+    if (!process.stdout.isTTY) {
+        return () => {};
+    }
+
+    let frameIndex = 0;
+
+    const render = () => {
+        const frame = FRAMES[frameIndex % FRAMES.length];
+        process.stdout.write(`\r${frame} ${text}`);
+        frameIndex++;
+    };
+
+    render();
+    const handle = setInterval(render, INTERVAL_MS);
+
+    return () => {
+        clearInterval(handle);
+        process.stdout.write("\r\x1b[K");
+    };
+}
+```
+
+Notes:
+- `\r` returns the cursor to column 0; `\x1b[K` clears from cursor to end of line.
+- When stdout is not a TTY (piped, redirected, CI), the function returns a no-op stop — nothing is written, nothing is cleared.
+- `render()` is called once immediately so the spinner appears instantly rather than 100ms later.
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 3: Quick standalone test**
+
+Run (from the project root):
+
+```bash
+node -e "const { startSpinner } = require('./dist/spinner'); const stop = startSpinner('Starting...'); setTimeout(() => { stop(); console.log('done'); }, 1500);"
+```
+
+Expected: spinner animates for 1.5 seconds, then the line clears and `done` prints cleanly (no lingering spinner chars).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/spinner.ts
+git commit -m "Add startSpinner utility"
+```
+
+---
+
+## Task 4: Wire the spinner into `createVmCommand` and fix the success message
+
+**Files:**
+- Modify: `src/commands/vm/create.ts` (imports at top, `apiClient.post` call around line 758, success message around line 798)
+
+- [ ] **Step 1: Import the spinner**
+
+Edit `src/commands/vm/create.ts`. Find the existing import block at the top of the file. After the line:
+
+```ts
+import { encryptDockerCredentials } from "../../services/encryption";
+```
+
+Add:
+
+```ts
+import { startSpinner } from "../../spinner";
+```
+
+- [ ] **Step 2: Wrap the `apiClient.post` call with the spinner**
+
+Find the `return await apiClient.post<CreateVmApiResponse>(` block (around line 758):
+
+```ts
+            return await apiClient.post<CreateVmApiResponse>(
+                API_ENDPOINTS.VM.CREATE,
+                formData,
+                {
+                    headers: {
+                        ...formData.getHeaders(), // Necessary for multipart/form-data with boundary
+                    },
+                    maxContentLength: Infinity, // Allow large file uploads
+                    maxBodyLength: Infinity, // Allow large file uploads
+                },
+            );
+```
+
+Replace with:
+
+```ts
+            const stopSpinner = globalOptions.interactive
+                ? startSpinner("Starting...")
+                : () => {};
+            try {
+                return await apiClient.post<CreateVmApiResponse>(
+                    API_ENDPOINTS.VM.CREATE,
+                    formData,
+                    {
+                        headers: {
+                            ...formData.getHeaders(), // Necessary for multipart/form-data with boundary
+                        },
+                        maxContentLength: Infinity, // Allow large file uploads
+                        maxBodyLength: Infinity, // Allow large file uploads
+                    },
+                );
+            } finally {
+                stopSpinner();
+            }
+```
+
+`finally` guarantees the spinner stops whether the request succeeds or throws.
+
+- [ ] **Step 3: Fix the success message text**
+
+Find the line (around line 798):
+
+```ts
+                    console.log(
+                        'You can check the VM status using the "list-vms" command shortly.',
+                    );
+```
+
+Replace with:
+
+```ts
+                    console.log(
+                        'You can check the VM status using the "vm list" command shortly.',
+                    );
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Smoke test the full flow**
+
+Run: `node dist/cli.js vm create`
+
+Complete the wizard with valid inputs against a staging/dev backend. Observe:
+- After the final prompt, `| Starting...` (or a rotating frame) appears and animates.
+- When the server responds, the spinner line clears cleanly (no leftover characters) before the result table prints.
+- The footer message reads `You can check the VM status using the "vm list" command shortly.`
+
+- [ ] **Step 6: Smoke test the non-interactive path**
+
+Run (with all required flags):
+
+```
+node dist/cli.js --non-interactive vm create -n test -t small -d path/to/compose.yml ...
+```
+
+Expected: no spinner output; JSON result printed as before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/vm/create.ts
+git commit -m "Show Starting... spinner during VM create; fix post-create message"
+```
+
+---
+
+## Verification summary
+
+After all tasks, confirm against the spec's testing section:
+
+1. `vm create --non-interactive ...` (no opt-out flag) → form data includes `upgradeability=1`. Verify by temporarily logging `formData` or using a local proxy.
+2. `vm create --non-interactive ... --disable-upgrades` → form data omits `upgradeability`.
+3. `vm create --non-interactive ... --upgradeability` → form data includes `upgradeability=1` (same as default).
+4. Interactive `vm create` → upgradeability prompt default is "yes".
+5. Interactive `vm create --disable-upgrades` → prompt is skipped.
+6. Interactive `vm create` in a TTY → spinner appears, clears cleanly.
+7. Non-interactive → no spinner.
+8. Piped stdout (e.g., `node dist/cli.js vm create | cat`) → no spinner characters.
+9. Post-create message → references `vm list`, not `list-vms`.
+
+If all pass, the branch is ready for PR.

--- a/docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md
+++ b/docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md
@@ -1,10 +1,12 @@
-# Upgrades-by-default for new VMs + startup animation
+# Upgrades-by-default for new VMs + startup animation + list-vms text fix
 
 ## Context
 
 `secretvm-cli vm create` currently creates VMs with upgradeability disabled unless the user opts in via `-u, --upgradeability` (non-interactive) or answers "yes" to the interactive prompt (which defaults to "no"). We want new VMs to be upgradeable by default, so users must now opt **out** instead of opting in.
 
 Separately, when the wizard finishes collecting input and the CLI posts to the create-VM endpoint, there's currently no visible feedback — the terminal just sits there until the server responds. We want a simple spinner + "Starting..." text to show the CLI is still working.
+
+Also, the success message after VM creation tells the user to run `list-vms`, but that command doesn't exist — the correct command is `vm list`. We'll fix the wording.
 
 ## Goals
 
@@ -13,6 +15,7 @@ Separately, when the wizard finishes collecting input and the CLI posts to the c
 - The existing `-u, --upgradeability` flag is kept as a silent no-op so existing scripts and documentation don't break.
 - Interactive and non-interactive modes behave consistently — the default is "on" in both.
 - While the create-VM request is in flight in interactive mode, show a simple ASCII spinner with the text "Starting...".
+- Fix the post-creation success message to reference the correct command name (`vm list` instead of `list-vms`).
 
 ## Non-goals
 
@@ -78,6 +81,18 @@ A small inline spinner utility, implemented with `setInterval`. No new dependenc
   This guarantees the spinner is cleared whether the request succeeds or errors.
 - The spinner starts *after* all interactive prompts have completed (i.e., right before the HTTP call), not during form assembly.
 
+### Success message wording (`src/commands/vm/create.ts`)
+
+In the interactive success handler, change:
+
+> `You can check the VM status using the "list-vms" command shortly.`
+
+to:
+
+> `You can check the VM status using the "vm list" command shortly.`
+
+No other message text changes.
+
 ## Testing
 
 This project does not currently have a test suite for `vm create`. Verification will be manual:
@@ -90,6 +105,7 @@ This project does not currently have a test suite for `vm create`. Verification 
 6. `secretvm-cli vm create` (interactive, TTY) → after all prompts, spinner shows `<frame> Starting...` until server responds, then clears cleanly before the result table prints.
 7. `secretvm-cli vm create ... --non-interactive` → no spinner, JSON output unchanged.
 8. Spinner output piped to a file → no spinner characters written (isTTY guard).
+9. `secretvm-cli vm create` (interactive) success output → references the `vm list` command (not `list-vms`).
 
 Verification can be done against a staging backend or by inspecting the outgoing `FormData` with a local proxy / console log if needed.
 

--- a/docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md
+++ b/docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md
@@ -1,8 +1,10 @@
-# Upgrades-by-default for new VMs
+# Upgrades-by-default for new VMs + startup animation
 
 ## Context
 
 `secretvm-cli vm create` currently creates VMs with upgradeability disabled unless the user opts in via `-u, --upgradeability` (non-interactive) or answers "yes" to the interactive prompt (which defaults to "no"). We want new VMs to be upgradeable by default, so users must now opt **out** instead of opting in.
+
+Separately, when the wizard finishes collecting input and the CLI posts to the create-VM endpoint, there's currently no visible feedback — the terminal just sits there until the server responds. We want a simple spinner + "Starting..." text to show the CLI is still working.
 
 ## Goals
 
@@ -10,12 +12,15 @@
 - Users can opt out explicitly via a new `--disable-upgrades` flag.
 - The existing `-u, --upgradeability` flag is kept as a silent no-op so existing scripts and documentation don't break.
 - Interactive and non-interactive modes behave consistently — the default is "on" in both.
+- While the create-VM request is in flight in interactive mode, show a simple ASCII spinner with the text "Starting...".
 
 ## Non-goals
 
 - Changing the server-side API contract. The server still accepts the `upgradeability=1` form field as today; we just send it by default.
 - Deprecation messaging or warnings for the old `--upgradeability` flag. It remains silently accepted.
 - Changing behavior for any other `vm` subcommand.
+- Adding a spinner to non-interactive output (would corrupt the JSON written by `successResponse`).
+- Adding a new dependency. The spinner will be implemented inline with `setInterval`.
 
 ## Design
 
@@ -52,6 +57,27 @@ cmdOptions.disableUpgrades ─► (interactive?) ─► prompt (default yes) ─
                               └─► non-interactive: use directly ──────┘
 ```
 
+### Startup animation (interactive mode only)
+
+A small inline spinner utility, implemented with `setInterval`. No new dependency.
+
+- Frames: `|`, `/`, `-`, `\`. Frame advances every ~100ms.
+- Rendered as a single line: `<frame> Starting...`, rewritten in place via `\r` + clear-to-end-of-line.
+- Two exported helpers in a new file `src/spinner.ts` (sibling to the existing `src/utils.ts`):
+  - `startSpinner(text: string): () => void` — starts the animation, returns a `stop` function that clears the line and stops the interval.
+  - Internal handling: if `process.stdout.isTTY` is false, `startSpinner` is a no-op (returns a stop that also does nothing). This keeps CI logs and piped output clean.
+- In `createVmCommand`, wrap the `apiClient.post(...)` call in interactive mode:
+  ```
+  const stop = globalOptions.interactive ? startSpinner("Starting...") : () => {};
+  try {
+      return await apiClient.post(...);
+  } finally {
+      stop();
+  }
+  ```
+  This guarantees the spinner is cleared whether the request succeeds or errors.
+- The spinner starts *after* all interactive prompts have completed (i.e., right before the HTTP call), not during form assembly.
+
 ## Testing
 
 This project does not currently have a test suite for `vm create`. Verification will be manual:
@@ -61,6 +87,9 @@ This project does not currently have a test suite for `vm create`. Verification 
 3. `secretvm-cli vm create --non-interactive ... --upgradeability` → server receives `upgradeability=1` (unchanged from today's outcome, flag is a no-op).
 4. `secretvm-cli vm create` (interactive) → upgradeability prompt defaults to "yes".
 5. `secretvm-cli vm create --disable-upgrades` (interactive) → prompt is skipped; VM is created without upgradeability.
+6. `secretvm-cli vm create` (interactive, TTY) → after all prompts, spinner shows `<frame> Starting...` until server responds, then clears cleanly before the result table prints.
+7. `secretvm-cli vm create ... --non-interactive` → no spinner, JSON output unchanged.
+8. Spinner output piped to a file → no spinner characters written (isTTY guard).
 
 Verification can be done against a staging backend or by inspecting the outgoing `FormData` with a local proxy / console log if needed.
 

--- a/docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md
+++ b/docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md
@@ -1,0 +1,70 @@
+# Upgrades-by-default for new VMs
+
+## Context
+
+`secretvm-cli vm create` currently creates VMs with upgradeability disabled unless the user opts in via `-u, --upgradeability` (non-interactive) or answers "yes" to the interactive prompt (which defaults to "no"). We want new VMs to be upgradeable by default, so users must now opt **out** instead of opting in.
+
+## Goals
+
+- New VMs are created with upgradeability enabled by default.
+- Users can opt out explicitly via a new `--disable-upgrades` flag.
+- The existing `-u, --upgradeability` flag is kept as a silent no-op so existing scripts and documentation don't break.
+- Interactive and non-interactive modes behave consistently — the default is "on" in both.
+
+## Non-goals
+
+- Changing the server-side API contract. The server still accepts the `upgradeability=1` form field as today; we just send it by default.
+- Deprecation messaging or warnings for the old `--upgradeability` flag. It remains silently accepted.
+- Changing behavior for any other `vm` subcommand.
+
+## Design
+
+### CLI surface (`src/cli.ts`)
+
+Keep the existing option and add a new opt-out:
+
+```
+-u, --upgradeability     (existing, now a silent no-op — kept for backwards compat)
+--disable-upgrades       (new, opts the VM out of upgradeability)
+```
+
+### Types (`src/types.d.ts`)
+
+Add `disableUpgrades?: boolean` to `CreateVmCommandOptions`. The existing `upgradeability?: boolean` stays.
+
+### Behavior (`src/commands/vm/create.ts`)
+
+The command resolves a single `upgradeability` boolean that is then used for form submission. How it's resolved depends on mode:
+
+- **Non-interactive mode:** `upgradeability = !cmdOptions.disableUpgrades`. No prompt.
+- **Interactive mode:**
+  - If `cmdOptions.disableUpgrades` is true, skip the prompt and set `upgradeability = false` (the user already expressed intent on the command line).
+  - Otherwise, show the existing prompt with its default flipped to `true`, and take the user's answer as the value.
+- **Form submission:** Append `upgradeability=1` whenever the resolved boolean is true. (This is the same append logic as today; we're just feeding it a different value.)
+
+The existing `cmdOptions.upgradeability` flag has no effect on behavior — with the new default, the state it used to request (upgradeability on) is already the default.
+
+### Data flow
+
+```
+cmdOptions.disableUpgrades ─► (interactive?) ─► prompt (default yes) ─┐
+                              │                                        ├─► upgradeability (bool) ─► form field append
+                              └─► non-interactive: use directly ──────┘
+```
+
+## Testing
+
+This project does not currently have a test suite for `vm create`. Verification will be manual:
+
+1. `secretvm-cli vm create --non-interactive ...` without either flag → server receives `upgradeability=1`.
+2. `secretvm-cli vm create --non-interactive ... --disable-upgrades` → server does not receive `upgradeability`.
+3. `secretvm-cli vm create --non-interactive ... --upgradeability` → server receives `upgradeability=1` (unchanged from today's outcome, flag is a no-op).
+4. `secretvm-cli vm create` (interactive) → upgradeability prompt defaults to "yes".
+5. `secretvm-cli vm create --disable-upgrades` (interactive) → prompt is skipped; VM is created without upgradeability.
+
+Verification can be done against a staging backend or by inspecting the outgoing `FormData` with a local proxy / console log if needed.
+
+## Risks and trade-offs
+
+- **Breaking change for non-interactive users** who relied on absence-of-flag meaning "not upgradeable". They'll need to add `--disable-upgrades` to their scripts. Mitigation: release notes should call this out.
+- **Silent no-op flag** (`--upgradeability`) is mildly confusing if a user reads the code and wonders what it does. Acceptable because removing it would break existing scripts.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,10 @@ async function main() {
         .option("-a, --private", "Enable private mode")
         .option("-u, --upgradeability", "Enable SecretVM upgradeability")
         .option(
+            "--disable-upgrades",
+            "Disable SecretVM upgradeability for this VM",
+        )
+        .option(
             "-f, --platform <sev|tdx>",
             "AMD SEV-SNP (sev) or Intel TDX (tdx) (default)",
         )

--- a/src/commands/vm/create.ts
+++ b/src/commands/vm/create.ts
@@ -302,7 +302,7 @@ export async function createVmCommand(
                             type: "input",
                             name: "inviteCode",
                             message:
-                                "Enter invite code (optional, press Enter if not needed):",
+                                "Enter invite code (optional, press Enter to skip):",
                         },
                     ]);
                     inviteCode = answers.inviteCode;
@@ -324,7 +324,7 @@ export async function createVmCommand(
                         {
                             type: "input",
                             name: "domain",
-                            message: "Enter your custom domain (FQDN):",
+                            message: "Enter custom domain (optional, press Enter for default):",
                         },
                     ]);
                     domain = answers.domain;

--- a/src/commands/vm/create.ts
+++ b/src/commands/vm/create.ts
@@ -16,6 +16,7 @@ import { API_ENDPOINTS } from "../../constants";
 import { AxiosResponse } from "axios";
 import yaml from "js-yaml";
 import { encryptDockerCredentials } from "../../services/encryption";
+import { startSpinner } from "../../spinner";
 
 export async function createVmCommand(
     cmdOptions: CreateVmCommandOptions,
@@ -33,7 +34,7 @@ export async function createVmCommand(
     let fsPersistence = cmdOptions.persistence;
     let platform = cmdOptions.platform;
     let privateMode = cmdOptions.private ?? false;
-    let upgradeability = cmdOptions.upgradeability;
+    let upgradeability = !cmdOptions.disableUpgrades;
     let environment = cmdOptions.environment;
     let secrets_plaintext: string | undefined;
     let dockerComposeContent: string | undefined;
@@ -401,14 +402,14 @@ export async function createVmCommand(
                     ]);
                     privateMode = enablePrivateMode;
                 }
-                if (!upgradeability) {
+                if (!cmdOptions.disableUpgrades) {
                     const { enableUpgradeability } = await inquirer.prompt([
                         {
                             type: "confirm",
                             name: "enableUpgradeability",
                             message:
                                 "Do you want to enable SecretVM upgradeability?",
-                            default: false,
+                            default: true,
                         },
                     ]);
                     upgradeability = enableUpgradeability;
@@ -755,17 +756,24 @@ export async function createVmCommand(
                 );
             }
 
-            return await apiClient.post<CreateVmApiResponse>(
-                API_ENDPOINTS.VM.CREATE,
-                formData,
-                {
-                    headers: {
-                        ...formData.getHeaders(), // Necessary for multipart/form-data with boundary
+            const stopSpinner = globalOptions.interactive
+                ? startSpinner("Starting...")
+                : () => {};
+            try {
+                return await apiClient.post<CreateVmApiResponse>(
+                    API_ENDPOINTS.VM.CREATE,
+                    formData,
+                    {
+                        headers: {
+                            ...formData.getHeaders(), // Necessary for multipart/form-data with boundary
+                        },
+                        maxContentLength: Infinity, // Allow large file uploads
+                        maxBodyLength: Infinity, // Allow large file uploads
                     },
-                    maxContentLength: Infinity, // Allow large file uploads
-                    maxBodyLength: Infinity, // Allow large file uploads
-                },
-            );
+                );
+            } finally {
+                stopSpinner();
+            }
         },
         (data: AxiosResponse) => {
             if (globalOptions.interactive) {
@@ -795,7 +803,7 @@ export async function createVmCommand(
                     ]);
                     console.log(table.toString());
                     console.log(
-                        'You can check the VM status using the "list-vms" command shortly.',
+                        'You can check the VM status using the "vm list" command shortly.',
                     );
                 } else {
                     console.log(

--- a/src/commands/vm/start.ts
+++ b/src/commands/vm/start.ts
@@ -40,7 +40,7 @@ export async function startVmCommand(
                     }
                     console.log("------------------------------------------");
                     console.log(
-                        `VM ID "${trimmedVmId}" is being started. Use "list-vms" to check its status shortly.`,
+                        `VM ID "${trimmedVmId}" is being started. Use "vm list" to check its status shortly.`,
                     );
                 } else {
                     console.log(

--- a/src/commands/vm/stop.ts
+++ b/src/commands/vm/stop.ts
@@ -33,7 +33,7 @@ export async function stopVmCommand(
                     }
                     console.log("------------------------------------------");
                     console.log(
-                        `VM ID "${trimmedVmId}" is being stopped. Use "list-vms" to check its status.`,
+                        `VM ID "${trimmedVmId}" is being stopped. Use "vm list" to check its status.`,
                     );
                 } else {
                     console.log(

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -1,0 +1,24 @@
+const FRAMES = ["|", "/", "-", "\\"];
+const INTERVAL_MS = 100;
+
+export function startSpinner(text: string): () => void {
+    if (!process.stdout.isTTY) {
+        return () => {};
+    }
+
+    let frameIndex = 0;
+
+    const render = () => {
+        const frame = FRAMES[frameIndex % FRAMES.length];
+        process.stdout.write(`\r${frame} ${text}`);
+        frameIndex++;
+    };
+
+    render();
+    const handle = setInterval(render, INTERVAL_MS);
+
+    return () => {
+        clearInterval(handle);
+        process.stdout.write("\r\x1b[K");
+    };
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -144,6 +144,7 @@ export interface CreateVmCommandOptions {
     dockerRegistry?: string;
     persistence?: boolean;
     upgradeability?: boolean;
+    disableUpgrades?: boolean;
     private?: boolean;
     platform?: string;
     environment?: string;


### PR DESCRIPTION
## Summary

- New VMs are now created **upgradeable by default**. Users can opt out with the new `--disable-upgrades` flag. The old `-u, --upgradeability` flag remains as a silent no-op for backwards compatibility.
- Adds a simple ASCII spinner (`| Starting...`) during the VM-create HTTP call in interactive mode, so the terminal isn't silent while the server works.
- Small UX polish: fixes stale `list-vms` references in the post-create/start/stop success messages (the command is actually `vm list`), and tightens wording on the custom-domain and invite-code prompts.

## Breaking change

Non-interactive callers that previously relied on absence of `--upgradeability` meaning "not upgradeable" will now get an upgradeable VM by default. To preserve the old behavior in scripts, add `--disable-upgrades`.

## Design docs

- Spec: `docs/superpowers/specs/2026-04-21-upgrades-by-default-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-upgrades-by-default.md`

## Test plan

- [ ] `secretvm-cli vm create` (interactive) — upgradeability prompt defaults to "yes"; spinner appears after the wizard and clears cleanly before the result table; success message references `"vm list"`.
- [ ] `secretvm-cli vm create --disable-upgrades` (interactive) — upgradeability prompt is skipped entirely; VM is created without upgradeability.
- [ ] `secretvm-cli --non-interactive vm create ...` — request includes `upgradeability=1` by default; no spinner output.
- [ ] `secretvm-cli --non-interactive vm create ... --disable-upgrades` — request omits `upgradeability`.
- [ ] `secretvm-cli vm start <id>` / `vm stop <id>` — success messages reference `"vm list"`, not `"list-vms"`.
- [ ] Output piped to a file — no spinner characters written (TTY guard).